### PR TITLE
add jib(docker) support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,11 @@ allprojects {
 	
 	eclipse {
 		/*第一次时请注释这段eclipse设置，可能报错*/
-		jdt  {
-		    File f = file('.settings/org.eclipse.core.resources.prefs')
-		    f.write('eclipse.preferences.version=1\n')
-		    f.append('encoding/<project>=UTF-8') //use UTF-8
-		}
+//		jdt  {
+//		    File f = file('.settings/org.eclipse.core.resources.prefs')
+//		    f.write('eclipse.preferences.version=1\n')
+//		    f.append('encoding/<project>=UTF-8') //use UTF-8
+//		}
 		
 		
 		/*

--- a/maxkey-web-manage/build.gradle
+++ b/maxkey-web-manage/build.gradle
@@ -1,3 +1,16 @@
+buildscript {
+	repositories {
+		jcenter()
+	}
+	dependencies {
+	}
+}
+
+plugins {
+	id 'com.google.cloud.tools.jib' version '2.6.0'
+	id 'org.springframework.boot' version '2.3.4.RELEASE'
+}
+
 description = "maxkey-web-manage"
 
 // Apply the java plugin to add support for Java
@@ -7,13 +20,18 @@ apply plugin: 'java'
 //apply plugin: 'com.bmuschko.tomcat-base'
 //apply plugin: 'com.bmuschko.tomcat'
 
-buildscript {
-  repositories {
-  jcenter()
-  }
-  dependencies {
-  	//classpath "com.bmuschko:gradle-tomcat-plugin:2.2.3"
-  }
+jib {
+	from {
+		image = 'adoptopenjdk:11-jre-openj9'
+	}
+	to {
+		image = "maxkey/maxkey-web-manage"
+		tags = ["${project.version}".toString(), 'latest']
+	}
+	container {
+		jvmFlags = ['-Dfile.encoding=utf-8', '-Dserver.port=80']
+		ports = ['80']
+	}
 }
 
 dependencies {

--- a/maxkey-web-maxkey/build.gradle
+++ b/maxkey-web-maxkey/build.gradle
@@ -1,3 +1,16 @@
+buildscript {
+	repositories {
+		jcenter()
+	}
+	dependencies {
+	}
+}
+
+plugins {
+	id 'com.google.cloud.tools.jib' version '2.6.0'
+	id 'org.springframework.boot' version '2.3.4.RELEASE'
+}
+
 description = "maxkey-web-maxkey"
 
 // Apply the java plugin to add support for Java
@@ -7,15 +20,21 @@ apply plugin: 'java'
 //apply plugin: 'com.bmuschko.tomcat-base'
 //apply plugin: 'com.bmuschko.tomcat'
 
-buildscript {
-  repositories {
-  jcenter()
-  }
-  dependencies {
-  	//classpath "com.bmuschko:gradle-tomcat-plugin:2.2.3"
-  }
+jib {
+	from {
+		image = 'adoptopenjdk:11-jre-openj9'
+	}
+	to {
+		image = "maxkey/maxkey-web-maxkey"
+		tags = ["${project.version}".toString(), 'latest']
+	}
+	container {
+		jvmFlags = ['-Dfile.encoding=utf-8', '-Dserver.port=80']
+		ports = ['80']
+	}
 }
-dependencies {         	
+
+dependencies {
 	compile project(":maxkey-core")
 	compile project(":maxkey-persistence")
    	


### PR DESCRIPTION
fix #20  add docker support

## Build Image 

```sh
# cd maxkey-web-maxkey  or cd maxkey-web-manage
gradle jibDockerBuild 
```

## Check Local Image
```sh
docker images | grep maxkey/
```

## Run with compose

```yaml
version: '2'
services:
    maxkey:
        image: maxkey/maxkey-web-maxkey
        ports:
            - 80:443
    maxkey-manage:
        image: maxkey/maxkey-web-manage
        ports:
            - 80:9521
```





